### PR TITLE
Static separator was changed to class attribute separator

### DIFF
--- a/CSVparser.cpp
+++ b/CSVparser.cpp
@@ -82,7 +82,7 @@ namespace csv {
          {
               if (it->at(i) == '"')
                   quoted = ((quoted) ? (false) : (true));
-              else if (it->at(i) == ',' && !quoted)
+              else if (it->at(i) == _sep && !quoted)
               {
                   row->push(it->substr(tokenStart, i - tokenStart));
                   tokenStart = i + 1;


### PR DESCRIPTION
The previous code only works if the csv separator is ','. In my case I usually use ';' as csv separator.